### PR TITLE
Add per-task options for modorganizer tasks

### DIFF
--- a/src/conf.h
+++ b/src/conf.h
@@ -3,6 +3,12 @@
 namespace mob
 {
 
+#define VALUE_PER_TASK(NAME) \
+	static decltype(auto) NAME(const std::vector<std::string>& names = {}) { return by_name(#NAME, names); }
+
+#define VALUE_BOOL_PER_TASK(NAME) \
+	static bool NAME(const std::vector<std::string>& names = {}) { return by_name_bool(#NAME, names); }
+
 #define VALUE(NAME) \
 	static decltype(auto) NAME() { return by_name(#NAME); }
 
@@ -93,16 +99,16 @@ struct conf
 	static int file_log_level();
 	static const fs::path& log_file();
 
-	static const std::string& by_name(const std::string& s);
-	static bool by_name_bool(const std::string& name);
+	static const std::string& by_name(const std::string& s, const std::vector<std::string>& task_names = {});
+	static bool by_name_bool(const std::string& name, const std::vector<std::string>& task_names = {});
 
-	VALUE(mo_org);
-	VALUE(mo_branch);
+	VALUE_PER_TASK(mo_org);
+	VALUE_PER_TASK(mo_branch);
 
-	VALUE_BOOL(dry);
-	VALUE_BOOL(redownload);
-	VALUE_BOOL(reextract);
-	VALUE_BOOL(rebuild);
+	VALUE_BOOL_PER_TASK(dry);
+	VALUE_BOOL_PER_TASK(redownload);
+	VALUE_BOOL_PER_TASK(reextract);
+	VALUE_BOOL_PER_TASK(rebuild);
 };
 
 struct prebuilt

--- a/src/tasks/modorganizer.cpp
+++ b/src/tasks/modorganizer.cpp
@@ -60,8 +60,8 @@ void modorganizer::do_fetch()
 	initialize_super(super_path());
 
 	run_tool(git_clone()
-		.url(make_github_url(conf::mo_org(), repo_))
-		.branch(conf::mo_branch())
+		.url(make_github_url(conf::mo_org(names()), repo_))
+		.branch(conf::mo_branch(names()))
 		.output(this_source_path()));
 }
 
@@ -76,10 +76,10 @@ void modorganizer::do_build_and_install()
 			.arg("submodule")
 			.arg("--quiet")
 			.arg("add")
-			.arg("-b", conf::mo_branch())
+			.arg("-b", conf::mo_branch(names()))
 			.arg("--force")
 			.arg("--name", name())
-			.arg(make_github_url(conf::mo_org(), repo_))
+			.arg(make_github_url(conf::mo_org(names()), repo_))
 			.arg(name())
 			.cwd(super_path())));
 	}


### PR DESCRIPTION
So, as I said, I went for a very simple way of having per-task options. I think per-task options are only relevant for `modorganizer-X` task, so I only handle those.

Per-task project looks like this:

```
[options]
mo_org    = ModOrganizer2
mo_branch = master
output_log_level = 3
file_log_level = 5
log_file = mob.log

[options-uibase]
mo_org    = Holt59
mo_branch = new-filetree
```

You can look at the code but it's pretty simple modification, I basically added a map from task name to options, and when a per-task section is found in the .ini, I first initialize the per-task option, and then set options appropriately.

When querying for an option, I give the list of potential names, and I check if there is a map available, otherwize, I default to the global option maps.

Some think that could be improved:
1. I don't like these `VALUE_PER_TASK` and `VALUE_BOOL_PER_TASK` but it did not make sense to have "per task" for other stuffs (tools, paths, etc.), so I had to separate the macro.
2. The global options are only taken into account if these are before the per-task options in the .ini file. I think it's enough for this task, but that's something that could be improved.
3. There is no check for the task name, and thus there can be two per-task section with 2 different names (e.g., `uibase` and `modorganizer-uibase`).

For 3, I thought about initializing the whole `g_task_options` before parsing the .ini file by using the list of modorganizer tasks available. By using short name, it is then possible to check that the per-task section match one of the name, and throw an error if it does not. Since there is no way to retrieve the list of tasks currently, I went this way. Another possibility would be to add a `task_exists` method to check when a section is encountered.