### PR TITLE
Configuration changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /vs/.vs
 /vs/*.user
 /mob.exe
+/mob.log

--- a/mob.ini
+++ b/mob.ini
@@ -10,6 +10,7 @@ log_file         = mob.log
 [options]
 mo_org           = ModOrganizer2
 mo_branch        = master
+no_pull          = false
 
 [tools]
 sevenz  = 7z.exe

--- a/mob.ini
+++ b/mob.ini
@@ -55,10 +55,10 @@ sip          = 5.1.2
 pyqt_sip     = 12.7.2
 explorerpp   = 1.3.5
 
-ss_6788_paper_lad      = 6.0
-ss_6788_paper_automata = 2.2
-ss_6788_paper_mono     = 2.1
-ss_6788_1809_dark_mode = 2.0
+ss_paper_lad_6788      = 6.0
+ss_paper_automata_6788 = 2.2
+ss_paper_mono_6788     = 2.1
+ss_dark_mode_1809_6788 = 2.0
 
 [paths]
 third_party         =

--- a/mob.ini
+++ b/mob.ini
@@ -1,9 +1,13 @@
 [options]
-mo_org    = ModOrganizer2
-mo_branch = master
+mo_org           = ModOrganizer2
+mo_branch        = master
+dry              = false
+redownload       = false
+reextract        = false
+rebuild          = false
 output_log_level = 3
-file_log_level = 5
-log_file = mob.log
+file_log_level   = 5
+log_file         = mob.log
 
 [tools]
 sevenz  = 7z.exe
@@ -16,6 +20,7 @@ devenv  = devenv.exe
 msbuild = msbuild.exe
 nuget   = nuget.exe
 vswhere = vswhere.exe
+nasm    = nasm.exe
 vcvars  =
 
 [prebuilt]
@@ -76,6 +81,7 @@ install_loot        =
 install_plugins     =
 install_stylesheets =
 install_licenses    =
+install_pythoncore  =
 vs                  =
 qt_install          =
 qt_bin              =

--- a/mob.ini
+++ b/mob.ini
@@ -1,6 +1,4 @@
-[options]
-mo_org           = ModOrganizer2
-mo_branch        = master
+[global]
 dry              = false
 redownload       = false
 reextract        = false
@@ -8,6 +6,10 @@ rebuild          = false
 output_log_level = 3
 file_log_level   = 5
 log_file         = mob.log
+
+[options]
+mo_org           = ModOrganizer2
+mo_branch        = master
 
 [tools]
 sevenz  = 7z.exe

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -123,22 +123,22 @@ int command::run()
 	if (o.output_log_level >= 0)
 	{
 		o.options.push_back(
-			"options/output_log_level=" +
+			"global/output_log_level=" +
 			std::to_string(o.output_log_level));
 	}
 
 	if (o.file_log_level > 0)
 	{
 		o.options.push_back(
-			"options/file_log_level=" +
+			"global/file_log_level=" +
 			std::to_string(o.file_log_level));
 	}
 
 	if (!o.log_file.empty())
-		o.options.push_back("options/log_file=" + o.log_file);
+		o.options.push_back("global/log_file=" + o.log_file);
 
 	if (o.dry)
-		o.options.push_back("options/dry=true");
+		o.options.push_back("global/dry=true");
 
 	if (!o.prefix.empty())
 		o.options.push_back("paths/prefix=" + o.prefix);

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -146,7 +146,7 @@ int command::run()
 	if (flags_ & requires_options)
 	{
 		init_options(command::common.ini, command::common.options);
-		dump_options();
+		log_options();
 
 		if (!verify_options())
 			return 1;

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -279,6 +279,9 @@ clipp::group build_command::do_group()
 		(clipp::option("-n", "--new") >> clean_)
 			% "deletes everything and starts from scratch",
 
+		(clipp::option("-p", "--no-pull") >> nopull_)
+		% "clones repos if necessary, but never pulls once cloned",
+
 		(clipp::option("--keep-msbuild") >> keep_msbuild_)
 			% "don't terminate msbuild.exe instances after building",
 
@@ -298,6 +301,9 @@ void build_command::do_pre_run()
 
 	if (rebuild_ || clean_)
 		common.options.push_back("options/rebuild=true");
+
+	if (nopull_)
+		common.options.push_back("options/no_pull=true");
 }
 
 int build_command::do_run()
@@ -329,7 +335,7 @@ void build_command::terminate_msbuild()
 	if (conf::dry())
 		return;
 
-	system("taskkill /im msbuild.exe /f > NUL");
+	system("taskkill /im msbuild.exe /f > NUL 2>&1");
 }
 
 

--- a/src/commands.h
+++ b/src/commands.h
@@ -15,8 +15,8 @@ public:
 		int file_log_level = -1;
 		std::string log_file;
 		std::vector<std::string> options;
-		std::vector<std::string> set;
-		std::string ini;
+		std::vector<std::string> inis;
+		bool no_default_inis = false;
 		std::string prefix;
 	};
 

--- a/src/commands.h
+++ b/src/commands.h
@@ -103,6 +103,7 @@ private:
 	bool reextract_ = false;
 	bool rebuild_ = false;
 	bool clean_ = false;
+	bool nopull_ = false;
 	bool keep_msbuild_ = false;
 
 	void terminate_msbuild();

--- a/src/conf.h
+++ b/src/conf.h
@@ -3,37 +3,32 @@
 namespace mob
 {
 
-#define VALUE(NAME) \
-	static decltype(auto) NAME() { return by_name(#NAME); }
-
-#define VALUE_BOOL(NAME) \
-	static bool NAME() { return by_name_bool(#NAME); }
+bool prebuilt_by_name(const std::string& task);
+std::string version_by_name(const std::string& s);
+fs::path tool_by_name(const std::string& s);
+fs::path path_by_name(const std::string& s);
+std::string conf_by_name(const std::string& s);
+bool bool_conf_by_name(const std::string& s);
 
 struct conf
 {
-	static void set_output_log_level(int i);
-	static void set_file_log_level(int i);
-	static void set_log_file(const fs::path& p);
-
 	static int output_log_level();
 	static int file_log_level();
-	static const fs::path& log_file();
 
-	static const std::string& by_name(const std::string& s);
-	static bool by_name_bool(const std::string& name);
+	static std::string mo_org()    { return conf_by_name("mo_org"); }
+	static std::string mo_branch() { return conf_by_name("mo_branch"); }
+	static fs::path log_file()     { return conf_by_name("log_file"); }
 
-	VALUE(mo_org);
-	VALUE(mo_branch);
-
-	VALUE_BOOL(dry);
-	VALUE_BOOL(redownload);
-	VALUE_BOOL(reextract);
-	VALUE_BOOL(rebuild);
+	static bool dry()        { return bool_conf_by_name("dry"); }
+	static bool redownload() { return bool_conf_by_name("redownload"); }
+	static bool reextract()  { return bool_conf_by_name("reextract"); }
+	static bool rebuild()    { return bool_conf_by_name("rebuild"); }
 };
 
 struct paths
 {
-	static const fs::path& by_name(const std::string& s);
+#define VALUE(NAME) \
+	static fs::path NAME() { return path_by_name(#NAME); }
 
 	VALUE(third_party);
 	VALUE(prefix);
@@ -57,19 +52,14 @@ struct paths
 	VALUE(pf_x86);
 	VALUE(pf_x64);
 	VALUE(temp_dir);
+
+#undef VALUE
 };
 
-#undef VALUE_BOOL
-#undef VALUE
-
-
-bool prebuilt_by_name(const std::string& task);
-const std::string& version_by_name(const std::string& s);
-const fs::path& tool_by_name(const std::string& s);
 
 void init_options(const fs::path& ini, const std::vector<std::string>& opts);
 bool verify_options();
-void dump_options();
+void log_options();
 void dump_available_options();
 
 fs::path make_temp_file();

--- a/src/conf.h
+++ b/src/conf.h
@@ -9,80 +9,6 @@ namespace mob
 #define VALUE_BOOL(NAME) \
 	static bool NAME() { return by_name_bool(#NAME); }
 
-
-namespace tools
-{
-	struct perl
-	{
-		static fs::path binary();
-	};
-
-	struct msbuild
-	{
-		static fs::path binary();
-	};
-
-	struct devenv
-	{
-		static fs::path binary();
-	};
-
-	struct cmake
-	{
-		static fs::path binary();
-	};
-
-	struct git
-	{
-		static fs::path binary();
-	};
-
-	struct sevenz
-	{
-		static fs::path binary();
-	};
-
-	struct jom
-	{
-		static fs::path binary();
-	};
-
-	struct nasm
-	{
-		static fs::path binary();
-	};
-
-	struct patch
-	{
-		static fs::path binary();
-	};
-
-	struct nuget
-	{
-		static fs::path binary();
-	};
-
-	struct vs
-	{
-		static fs::path installation_path();
-		static fs::path vswhere();
-		static fs::path vcvars();
-		static std::string version();
-		static std::string year();
-		static std::string toolset();
-		static std::string sdk();
-	};
-
-	struct qt
-	{
-		static fs::path installation_path();
-		static fs::path bin_path();
-		static std::string version();
-		static std::string vs_version();
-	};
-};
-
-
 struct conf
 {
 	static void set_output_log_level(int i);
@@ -103,21 +29,6 @@ struct conf
 	VALUE_BOOL(redownload);
 	VALUE_BOOL(reextract);
 	VALUE_BOOL(rebuild);
-};
-
-struct prebuilt
-{
-	static bool by_name(const std::string& s);
-};
-
-struct versions
-{
-	static const std::string& by_name(const std::string& s);
-
-	VALUE(ss_6788_paper_lad);
-	VALUE(ss_6788_paper_automata);
-	VALUE(ss_6788_paper_mono);
-	VALUE(ss_6788_1809_dark_mode);
 };
 
 struct paths
@@ -151,6 +62,10 @@ struct paths
 #undef VALUE_BOOL
 #undef VALUE
 
+
+bool prebuilt_by_name(const std::string& task);
+const std::string& version_by_name(const std::string& s);
+const fs::path& tool_by_name(const std::string& s);
 
 void init_options(const fs::path& ini, const std::vector<std::string>& opts);
 bool verify_options();

--- a/src/conf.h
+++ b/src/conf.h
@@ -3,32 +3,83 @@
 namespace mob
 {
 
-bool prebuilt_by_name(const std::string& task);
-std::string version_by_name(const std::string& s);
-fs::path tool_by_name(const std::string& s);
-fs::path path_by_name(const std::string& s);
-std::string conf_by_name(const std::string& s);
-bool bool_conf_by_name(const std::string& s);
-
-struct conf
+class conf
 {
-	static int output_log_level();
-	static int file_log_level();
+public:
+	static std::string get_global(
+		const std::string& section, const std::string& key);
 
-	static std::string mo_org()    { return conf_by_name("mo_org"); }
-	static std::string mo_branch() { return conf_by_name("mo_branch"); }
-	static fs::path log_file()     { return conf_by_name("log_file"); }
+	static void set_global(
+		const std::string& section,
+		const std::string& key, const std::string& value);
 
-	static bool dry()        { return bool_conf_by_name("dry"); }
-	static bool redownload() { return bool_conf_by_name("redownload"); }
-	static bool reextract()  { return bool_conf_by_name("reextract"); }
-	static bool rebuild()    { return bool_conf_by_name("rebuild"); }
+	static void add_global(
+		const std::string& section,
+		const std::string& key, const std::string& value);
+
+
+	static std::string get_for_task(
+		const std::vector<std::string>& task_names,
+		const std::string& section, const std::string& key);
+
+	static void set_for_task(
+		const std::string& task_name, const std::string& section,
+		const std::string& key, const std::string& value);
+
+
+	static bool prebuilt_by_name(const std::string& task);
+	static fs::path path_by_name(const std::string& name);
+	static std::string version_by_name(const std::string& name);
+	static fs::path tool_by_name(const std::string& name);
+
+	static std::string global_by_name(const std::string& name);
+	static bool bool_global_by_name(const std::string& name);
+
+	static std::string option_by_name(
+		const std::vector<std::string>& task_names, const std::string& name);
+
+
+	static int output_log_level() { return output_log_level_; }
+	static void set_output_log_level(const std::string& s);
+
+	static int file_log_level()   { return file_log_level_; }
+	static void set_file_log_level(const std::string& s);
+
+	static fs::path log_file() { return global_by_name("log_file"); }
+	static bool dry()          { return bool_global_by_name("dry"); }
+	static bool redownload()   { return bool_global_by_name("redownload"); }
+	static bool reextract()    { return bool_global_by_name("reextract"); }
+	static bool rebuild()      { return bool_global_by_name("rebuild"); }
+
+
+	static std::string mo_org(const std::vector<std::string>& task_names)
+	{
+		return option_by_name(task_names, "mo_org");
+	}
+
+	static std::string mo_branch(const std::vector<std::string>& task_names)
+	{
+		return option_by_name(task_names, "mo_branch");
+	}
+
+	static std::vector<std::string> format_options();
+
+private:
+	using key_value_map = std::map<std::string, std::string>;
+	using section_map = std::map<std::string, key_value_map>;
+	using task_map = std::map<std::string, section_map>;
+
+	static task_map map_;
+
+	// special cases to avoid string manipulations
+	static int output_log_level_;
+	static int file_log_level_;
 };
 
 struct paths
 {
 #define VALUE(NAME) \
-	static fs::path NAME() { return path_by_name(#NAME); }
+	static fs::path NAME() { return conf::path_by_name(#NAME); }
 
 	VALUE(third_party);
 	VALUE(prefix);

--- a/src/conf.h
+++ b/src/conf.h
@@ -38,6 +38,9 @@ public:
 	static std::string option_by_name(
 		const std::vector<std::string>& task_names, const std::string& name);
 
+	static bool bool_option_by_name(
+		const std::vector<std::string>& task_names, const std::string& name);
+
 
 	static int output_log_level() { return output_log_level_; }
 	static void set_output_log_level(const std::string& s);
@@ -50,17 +53,6 @@ public:
 	static bool redownload()   { return bool_global_by_name("redownload"); }
 	static bool reextract()    { return bool_global_by_name("reextract"); }
 	static bool rebuild()      { return bool_global_by_name("rebuild"); }
-
-
-	static std::string mo_org(const std::vector<std::string>& task_names)
-	{
-		return option_by_name(task_names, "mo_org");
-	}
-
-	static std::string mo_branch(const std::vector<std::string>& task_names)
-	{
-		return option_by_name(task_names, "mo_branch");
-	}
 
 	static std::vector<std::string> format_options();
 
@@ -75,6 +67,7 @@ private:
 	static int output_log_level_;
 	static int file_log_level_;
 };
+
 
 struct paths
 {

--- a/src/conf.h
+++ b/src/conf.h
@@ -57,7 +57,12 @@ struct paths
 };
 
 
-void init_options(const fs::path& ini, const std::vector<std::string>& opts);
+std::string master_ini_filename();
+
+void init_options(
+	const std::vector<fs::path>& inis_from_cl, bool auto_detection,
+	const std::vector<std::string>& opts);
+
 bool verify_options();
 void log_options();
 void dump_available_options();

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -4,6 +4,7 @@
 #include "process.h"
 #include "op.h"
 #include "context.h"
+#include "tools/tools.h"
 
 namespace mob
 {
@@ -33,7 +34,7 @@ env get_vcvars_env(arch a)
 
 	// "vcvarsall.bat" amd64 && set > temp_file
 	const std::string cmd =
-		"\"" + path_to_utf8(tools::vs::vcvars()) + "\" " + arch_s +
+		"\"" + path_to_utf8(vs::vcvars()) + "\" " + arch_s +
 		" && set > \"" + path_to_utf8(tmp) + "\"";
 
 	process::raw(gcx(), cmd)

--- a/src/op.cpp
+++ b/src/op.cpp
@@ -4,6 +4,7 @@
 #include "conf.h"
 #include "context.h"
 #include "process.h"
+#include "tools/tools.h"
 
 namespace mob::op
 {
@@ -487,7 +488,7 @@ void archive_from_glob(
 	op::create_directories(cx, dest_file.parent_path());
 
 	auto p = process()
-		.binary(tools::sevenz::binary())
+		.binary(extractor::binary())
 		.arg("a")
 		.arg(dest_file)
 		.arg("-r")
@@ -543,7 +544,7 @@ void archive_from_files(
 	op::create_directories(cx, dest_file.parent_path());
 
 	auto p = process()
-		.binary(tools::sevenz::binary())
+		.binary(extractor::binary())
 		.arg("a")
 		.arg(dest_file)
 		.arg("@", list_file, process::nospace)

--- a/src/tasks/boost.cpp
+++ b/src/tasks/boost.cpp
@@ -9,12 +9,12 @@ boost::boost()
 {
 }
 
-const std::string& boost::version()
+std::string boost::version()
 {
 	return version_by_name("boost");
 }
 
-const std::string& boost::version_vs()
+std::string boost::version_vs()
 {
 	return version_by_name("boost_vs");
 }
@@ -195,8 +195,10 @@ std::smatch boost::parse_boost_version()
 	std::regex re(R"((\d+)\.(\d+)(?:\.(\d+)(?:-(\w+)(?:-(\w+))?)?)?)");
 	std::smatch m;
 
-	if (!std::regex_match(version(), m, re))
-		bail_out("bad boost version '{}'", version());
+	const auto s = version();
+
+	if (!std::regex_match(s, m, re))
+		bail_out("bad boost version '{}'", s);
 
 	return m;
 }

--- a/src/tasks/boost.cpp
+++ b/src/tasks/boost.cpp
@@ -11,17 +11,17 @@ boost::boost()
 
 const std::string& boost::version()
 {
-	return versions::by_name("boost");
+	return version_by_name("boost");
 }
 
 const std::string& boost::version_vs()
 {
-	return versions::by_name("boost_vs");
+	return version_by_name("boost_vs");
 }
 
 bool boost::prebuilt()
 {
-	return prebuilt::by_name("boost");
+	return prebuilt_by_name("boost");
 }
 
 fs::path boost::source_path()
@@ -152,7 +152,7 @@ void boost::do_b2(
 		.arg("address-model=",  address_model_for_arch(a))
 		.arg("link=",           link)
 		.arg("runtime-link=",   runtime_link)
-		.arg("toolset=",        "msvc-" + tools::vs::toolset())
+		.arg("toolset=",        "msvc-" + vs::toolset())
 		.arg("--user-config=",  config_jam_file())
 		.arg("--stagedir=",     root_lib_path(a))
 		.arg("--libdir=",       root_lib_path(a))

--- a/src/tasks/boost.cpp
+++ b/src/tasks/boost.cpp
@@ -11,17 +11,17 @@ boost::boost()
 
 std::string boost::version()
 {
-	return version_by_name("boost");
+	return conf::version_by_name("boost");
 }
 
 std::string boost::version_vs()
 {
-	return version_by_name("boost_vs");
+	return conf::version_by_name("boost_vs");
 }
 
 bool boost::prebuilt()
 {
-	return prebuilt_by_name("boost");
+	return conf::prebuilt_by_name("boost");
 }
 
 fs::path boost::source_path()

--- a/src/tasks/boost_di.cpp
+++ b/src/tasks/boost_di.cpp
@@ -9,10 +9,9 @@ boost_di::boost_di()
 {
 }
 
-const std::string& boost_di::version()
+std::string boost_di::version()
 {
-	static std::string s;
-	return s;
+	return {};
 }
 
 bool boost_di::prebuilt()

--- a/src/tasks/boost_di.cpp
+++ b/src/tasks/boost_di.cpp
@@ -27,7 +27,7 @@ fs::path boost_di::source_path()
 
 void boost_di::do_fetch()
 {
-	run_tool(git_clone()
+	run_tool(git(git::clone_or_pull)
 		.url(make_github_url("boost-experimental", "di"))
 		.branch("cpp14")
 		.output(source_path()));

--- a/src/tasks/boost_di.cpp
+++ b/src/tasks/boost_di.cpp
@@ -26,7 +26,7 @@ fs::path boost_di::source_path()
 
 void boost_di::do_fetch()
 {
-	run_tool(git(git::clone_or_pull)
+	run_tool(git(task_conf().git_op())
 		.url(make_github_url("boost-experimental", "di"))
 		.branch("cpp14")
 		.output(source_path()));

--- a/src/tasks/bzip2.cpp
+++ b/src/tasks/bzip2.cpp
@@ -9,7 +9,7 @@ bzip2::bzip2()
 {
 }
 
-const std::string& bzip2::version()
+std::string bzip2::version()
 {
 	return version_by_name("bzip2");
 }

--- a/src/tasks/bzip2.cpp
+++ b/src/tasks/bzip2.cpp
@@ -11,7 +11,7 @@ bzip2::bzip2()
 
 const std::string& bzip2::version()
 {
-	return versions::by_name("bzip2");
+	return version_by_name("bzip2");
 }
 
 bool bzip2::prebuilt()

--- a/src/tasks/bzip2.cpp
+++ b/src/tasks/bzip2.cpp
@@ -11,7 +11,7 @@ bzip2::bzip2()
 
 std::string bzip2::version()
 {
-	return version_by_name("bzip2");
+	return conf::version_by_name("bzip2");
 }
 
 bool bzip2::prebuilt()

--- a/src/tasks/explorerpp.cpp
+++ b/src/tasks/explorerpp.cpp
@@ -11,7 +11,7 @@ explorerpp::explorerpp()
 
 const std::string& explorerpp::version()
 {
-	return versions::by_name("explorerpp");
+	return version_by_name("explorerpp");
 }
 
 bool explorerpp::prebuilt()

--- a/src/tasks/explorerpp.cpp
+++ b/src/tasks/explorerpp.cpp
@@ -9,7 +9,7 @@ explorerpp::explorerpp()
 {
 }
 
-const std::string& explorerpp::version()
+std::string explorerpp::version()
 {
 	return version_by_name("explorerpp");
 }

--- a/src/tasks/explorerpp.cpp
+++ b/src/tasks/explorerpp.cpp
@@ -11,7 +11,7 @@ explorerpp::explorerpp()
 
 std::string explorerpp::version()
 {
-	return version_by_name("explorerpp");
+	return conf::version_by_name("explorerpp");
 }
 
 bool explorerpp::prebuilt()

--- a/src/tasks/fmt.cpp
+++ b/src/tasks/fmt.cpp
@@ -11,7 +11,7 @@ fmt::fmt()
 
 const std::string& fmt::version()
 {
-	return versions::by_name("fmt");
+	return version_by_name("fmt");
 }
 
 bool fmt::prebuilt()

--- a/src/tasks/fmt.cpp
+++ b/src/tasks/fmt.cpp
@@ -11,7 +11,7 @@ fmt::fmt()
 
 std::string fmt::version()
 {
-	return version_by_name("fmt");
+	return conf::version_by_name("fmt");
 }
 
 bool fmt::prebuilt()

--- a/src/tasks/fmt.cpp
+++ b/src/tasks/fmt.cpp
@@ -9,7 +9,7 @@ fmt::fmt()
 {
 }
 
-const std::string& fmt::version()
+std::string fmt::version()
 {
 	return version_by_name("fmt");
 }

--- a/src/tasks/gtest.cpp
+++ b/src/tasks/gtest.cpp
@@ -11,7 +11,7 @@ gtest::gtest()
 
 std::string gtest::version()
 {
-	return version_by_name("gtest");
+	return conf::version_by_name("gtest");
 }
 
 bool gtest::prebuilt()

--- a/src/tasks/gtest.cpp
+++ b/src/tasks/gtest.cpp
@@ -9,7 +9,7 @@ gtest::gtest()
 {
 }
 
-const std::string& gtest::version()
+std::string gtest::version()
 {
 	return version_by_name("gtest");
 }

--- a/src/tasks/gtest.cpp
+++ b/src/tasks/gtest.cpp
@@ -31,7 +31,7 @@ void gtest::do_clean_for_rebuild()
 
 void gtest::do_fetch()
 {
-	run_tool(git(git::clone_or_pull)
+	run_tool(git(task_conf().git_op())
 		.url(make_github_url("google", "googletest"))
 		.branch(version())
 		.output(source_path()));

--- a/src/tasks/gtest.cpp
+++ b/src/tasks/gtest.cpp
@@ -11,7 +11,7 @@ gtest::gtest()
 
 const std::string& gtest::version()
 {
-	return versions::by_name("gtest");
+	return version_by_name("gtest");
 }
 
 bool gtest::prebuilt()
@@ -31,7 +31,7 @@ void gtest::do_clean_for_rebuild()
 
 void gtest::do_fetch()
 {
-	run_tool(git_clone()
+	run_tool(git(git::clone_or_pull)
 		.url(make_github_url("google", "googletest"))
 		.branch(version())
 		.output(source_path()));

--- a/src/tasks/libbsarch.cpp
+++ b/src/tasks/libbsarch.cpp
@@ -9,7 +9,7 @@ libbsarch::libbsarch()
 {
 }
 
-const std::string& libbsarch::version()
+std::string libbsarch::version()
 {
 	return version_by_name("libbsarch");
 }

--- a/src/tasks/libbsarch.cpp
+++ b/src/tasks/libbsarch.cpp
@@ -11,7 +11,7 @@ libbsarch::libbsarch()
 
 std::string libbsarch::version()
 {
-	return version_by_name("libbsarch");
+	return conf::version_by_name("libbsarch");
 }
 
 bool libbsarch::prebuilt()

--- a/src/tasks/libbsarch.cpp
+++ b/src/tasks/libbsarch.cpp
@@ -11,7 +11,7 @@ libbsarch::libbsarch()
 
 const std::string& libbsarch::version()
 {
-	return versions::by_name("libbsarch");
+	return version_by_name("libbsarch");
 }
 
 bool libbsarch::prebuilt()

--- a/src/tasks/libffi.cpp
+++ b/src/tasks/libffi.cpp
@@ -27,7 +27,7 @@ fs::path libffi::source_path()
 
 void libffi::do_fetch()
 {
-	run_tool(git_clone()
+	run_tool(git(git::clone_or_pull)
 		.url(make_github_url("python","cpython-bin-deps"))
 		.branch("libffi")
 		.output(source_path()));

--- a/src/tasks/libffi.cpp
+++ b/src/tasks/libffi.cpp
@@ -9,10 +9,9 @@ libffi::libffi()
 {
 }
 
-const std::string& libffi::version()
+std::string libffi::version()
 {
-	static std::string s;
-	return s;
+	return {};
 }
 
 bool libffi::prebuilt()

--- a/src/tasks/libffi.cpp
+++ b/src/tasks/libffi.cpp
@@ -26,7 +26,7 @@ fs::path libffi::source_path()
 
 void libffi::do_fetch()
 {
-	run_tool(git(git::clone_or_pull)
+	run_tool(git(task_conf().git_op())
 		.url(make_github_url("python","cpython-bin-deps"))
 		.branch("libffi")
 		.output(source_path()));

--- a/src/tasks/libloot.cpp
+++ b/src/tasks/libloot.cpp
@@ -11,12 +11,12 @@ libloot::libloot()
 
 const std::string& libloot::version()
 {
-	return versions::by_name("libloot");
+	return version_by_name("libloot");
 }
 
 const std::string& libloot::hash()
 {
-	return versions::by_name("libloot_hash");
+	return version_by_name("libloot_hash");
 }
 
 bool libloot::prebuilt()

--- a/src/tasks/libloot.cpp
+++ b/src/tasks/libloot.cpp
@@ -9,12 +9,12 @@ libloot::libloot()
 {
 }
 
-const std::string& libloot::version()
+std::string libloot::version()
 {
 	return version_by_name("libloot");
 }
 
-const std::string& libloot::hash()
+std::string libloot::hash()
 {
 	return version_by_name("libloot_hash");
 }

--- a/src/tasks/libloot.cpp
+++ b/src/tasks/libloot.cpp
@@ -11,12 +11,12 @@ libloot::libloot()
 
 std::string libloot::version()
 {
-	return version_by_name("libloot");
+	return conf::version_by_name("libloot");
 }
 
 std::string libloot::hash()
 {
-	return version_by_name("libloot_hash");
+	return conf::version_by_name("libloot_hash");
 }
 
 bool libloot::prebuilt()

--- a/src/tasks/licenses.cpp
+++ b/src/tasks/licenses.cpp
@@ -9,10 +9,9 @@ licenses::licenses()
 {
 }
 
-const std::string& licenses::version()
+std::string licenses::version()
 {
-	static std::string s;
-	return s;
+	return {};
 }
 
 bool licenses::prebuilt()

--- a/src/tasks/lz4.cpp
+++ b/src/tasks/lz4.cpp
@@ -11,12 +11,12 @@ lz4::lz4()
 
 std::string lz4::version()
 {
-	return version_by_name("lz4");
+	return conf::version_by_name("lz4");
 }
 
 bool lz4::prebuilt()
 {
-	return prebuilt_by_name("lz4");
+	return conf::prebuilt_by_name("lz4");
 }
 
 fs::path lz4::source_path()

--- a/src/tasks/lz4.cpp
+++ b/src/tasks/lz4.cpp
@@ -11,12 +11,12 @@ lz4::lz4()
 
 const std::string& lz4::version()
 {
-	return versions::by_name("lz4");
+	return version_by_name("lz4");
 }
 
 bool lz4::prebuilt()
 {
-	return prebuilt::by_name("lz4");
+	return prebuilt_by_name("lz4");
 }
 
 fs::path lz4::source_path()
@@ -72,12 +72,13 @@ void lz4::build_and_install_prebuilt()
 
 void lz4::fetch_from_source()
 {
-	run_tool(git_clone()
+	run_tool(git(git::clone_or_pull)
 		.url(make_github_url("lz4","lz4"))
 		.branch(version())
 		.output(source_path()));
 
-	run_tool(devenv_upgrade(solution_file()));
+	run_tool(vs(vs::upgrade)
+		.solution(solution_file()));
 }
 
 void lz4::build_and_install_from_source()

--- a/src/tasks/lz4.cpp
+++ b/src/tasks/lz4.cpp
@@ -72,7 +72,7 @@ void lz4::build_and_install_prebuilt()
 
 void lz4::fetch_from_source()
 {
-	run_tool(git(git::clone_or_pull)
+	run_tool(git(task_conf().git_op())
 		.url(make_github_url("lz4","lz4"))
 		.branch(version())
 		.output(source_path()));

--- a/src/tasks/lz4.cpp
+++ b/src/tasks/lz4.cpp
@@ -9,7 +9,7 @@ lz4::lz4()
 {
 }
 
-const std::string& lz4::version()
+std::string lz4::version()
 {
 	return version_by_name("lz4");
 }

--- a/src/tasks/modorganizer.cpp
+++ b/src/tasks/modorganizer.cpp
@@ -24,10 +24,9 @@ modorganizer::modorganizer(std::string long_name)
 		add_name(long_name);
 }
 
-const std::string& modorganizer::version()
+std::string modorganizer::version()
 {
-	static std::string s;
-	return s;
+	return {};
 }
 
 bool modorganizer::prebuilt()

--- a/src/tasks/modorganizer.cpp
+++ b/src/tasks/modorganizer.cpp
@@ -58,9 +58,9 @@ void modorganizer::do_fetch()
 {
 	initialize_super(super_path());
 
-	run_tool(git(git::clone_or_pull)
-		.url(make_github_url(conf::mo_org(names()), repo_))
-		.branch(conf::mo_branch(names()))
+	run_tool(git(task_conf().git_op())
+		.url(make_github_url(task_conf().mo_org(), repo_))
+		.branch(task_conf().mo_branch())
 		.output(this_source_path()));
 }
 
@@ -75,10 +75,10 @@ void modorganizer::do_build_and_install()
 			.arg("submodule")
 			.arg("--quiet")
 			.arg("add")
-			.arg("-b", conf::mo_branch(names()))
+			.arg("-b", task_conf().mo_branch())
 			.arg("--force")
 			.arg("--name", name())
-			.arg(make_github_url(conf::mo_org(names()), repo_))
+			.arg(make_github_url(task_conf().mo_org(), repo_))
 			.arg(name())
 			.cwd(super_path())));
 	}

--- a/src/tasks/modorganizer.cpp
+++ b/src/tasks/modorganizer.cpp
@@ -59,7 +59,7 @@ void modorganizer::do_fetch()
 {
 	initialize_super(super_path());
 
-	run_tool(git_clone()
+	run_tool(git(git::clone_or_pull)
 		.url(make_github_url(conf::mo_org(), repo_))
 		.branch(conf::mo_branch())
 		.output(this_source_path()));
@@ -71,7 +71,7 @@ void modorganizer::do_build_and_install()
 		std::scoped_lock lock(g_super_mutex);
 
 		run_tool(process_runner(process()
-			.binary(tools::git::binary())
+			.binary(git::binary())
 			.arg("-c", "core.autocrlf=false")
 			.arg("submodule")
 			.arg("--quiet")
@@ -102,7 +102,7 @@ void modorganizer::do_build_and_install()
 		.def("SPDLOG_ROOT",        spdlog::source_path())
 		.def("LOOT_PATH",          libloot::source_path())
 		.def("LZ4_ROOT",           lz4::source_path())
-		.def("QT_ROOT",            tools::qt::installation_path())
+		.def("QT_ROOT",            qt::installation_path())
 		.def("ZLIB_ROOT",          zlib::source_path())
 		.def("PYTHON_ROOT",        python::source_path())
 		.def("SEVENZ_ROOT",        sevenz::source_path())
@@ -137,7 +137,7 @@ void modorganizer::initialize_super(const fs::path& super_root)
 	cx().trace(context::generic, "checking super");
 
 	auto p = process()
-		.binary(tools::git::binary())
+		.binary(git::binary())
 		.arg("rev-parse")
 		.arg("--is-inside-work-tree")
 		.stderr_filter([](process::filter& f)
@@ -157,7 +157,7 @@ void modorganizer::initialize_super(const fs::path& super_root)
 	cx().trace(context::generic, "initializing super");
 
 	run_tool(process_runner(process()
-		.binary(tools::git::binary())
+		.binary(git::binary())
 		.arg("init")
 		.cwd(super_root)));
 }

--- a/src/tasks/modorganizer.cpp
+++ b/src/tasks/modorganizer.cpp
@@ -59,8 +59,8 @@ void modorganizer::do_fetch()
 	initialize_super(super_path());
 
 	run_tool(git(git::clone_or_pull)
-		.url(make_github_url(conf::mo_org(), repo_))
-		.branch(conf::mo_branch())
+		.url(make_github_url(conf::mo_org(names()), repo_))
+		.branch(conf::mo_branch(names()))
 		.output(this_source_path()));
 }
 
@@ -75,10 +75,10 @@ void modorganizer::do_build_and_install()
 			.arg("submodule")
 			.arg("--quiet")
 			.arg("add")
-			.arg("-b", conf::mo_branch())
+			.arg("-b", conf::mo_branch(names()))
 			.arg("--force")
 			.arg("--name", name())
-			.arg(make_github_url(conf::mo_org(), repo_))
+			.arg(make_github_url(conf::mo_org(names()), repo_))
 			.arg(name())
 			.cwd(super_path())));
 	}

--- a/src/tasks/ncc.cpp
+++ b/src/tasks/ncc.cpp
@@ -33,7 +33,7 @@ void ncc::do_clean_for_rebuild()
 
 void ncc::do_fetch()
 {
-	run_tool(git_clone()
+	run_tool(git(git::clone_or_pull)
 		.url(make_github_url(conf::mo_org(), "modorganizer-NCC"))
 		.branch(conf::mo_branch())
 		.output(source_path()));

--- a/src/tasks/ncc.cpp
+++ b/src/tasks/ncc.cpp
@@ -33,8 +33,8 @@ void ncc::do_clean_for_rebuild()
 void ncc::do_fetch()
 {
 	run_tool(git(git::clone_or_pull)
-		.url(make_github_url(conf::mo_org(), "modorganizer-NCC"))
-		.branch(conf::mo_branch())
+		.url(make_github_url(conf::mo_org(names()), "modorganizer-NCC"))
+		.branch(conf::mo_branch(names()))
 		.output(source_path()));
 }
 

--- a/src/tasks/ncc.cpp
+++ b/src/tasks/ncc.cpp
@@ -9,10 +9,9 @@ ncc::ncc()
 {
 }
 
-const std::string& ncc::version()
+std::string ncc::version()
 {
-	static std::string s;
-	return s;
+	return {};
 }
 
 bool ncc::prebuilt()

--- a/src/tasks/ncc.cpp
+++ b/src/tasks/ncc.cpp
@@ -32,9 +32,9 @@ void ncc::do_clean_for_rebuild()
 
 void ncc::do_fetch()
 {
-	run_tool(git(git::clone_or_pull)
-		.url(make_github_url(conf::mo_org(names()), "modorganizer-NCC"))
-		.branch(conf::mo_branch(names()))
+	run_tool(git(task_conf().git_op())
+		.url(make_github_url(task_conf().mo_org(), "modorganizer-NCC"))
+		.branch(task_conf().mo_branch())
 		.output(source_path()));
 }
 

--- a/src/tasks/nmm.cpp
+++ b/src/tasks/nmm.cpp
@@ -9,7 +9,7 @@ nmm::nmm()
 {
 }
 
-const std::string& nmm::version()
+std::string nmm::version()
 {
 	return version_by_name("nmm");
 }

--- a/src/tasks/nmm.cpp
+++ b/src/tasks/nmm.cpp
@@ -11,7 +11,7 @@ nmm::nmm()
 
 const std::string& nmm::version()
 {
-	return versions::by_name("nmm");
+	return version_by_name("nmm");
 }
 
 bool nmm::prebuilt()
@@ -31,7 +31,7 @@ void nmm::do_clean_for_rebuild()
 
 void nmm::do_fetch()
 {
-	run_tool(git_clone()
+	run_tool(git(git::clone_or_pull)
 		.url(make_github_url("Nexus-Mods", "Nexus-Mod-Manager"))
 		.branch(version())
 		.output(source_path()));

--- a/src/tasks/nmm.cpp
+++ b/src/tasks/nmm.cpp
@@ -31,7 +31,7 @@ void nmm::do_clean_for_rebuild()
 
 void nmm::do_fetch()
 {
-	run_tool(git(git::clone_or_pull)
+	run_tool(git(task_conf().git_op())
 		.url(make_github_url("Nexus-Mods", "Nexus-Mod-Manager"))
 		.branch(version())
 		.output(source_path()));

--- a/src/tasks/nmm.cpp
+++ b/src/tasks/nmm.cpp
@@ -11,7 +11,7 @@ nmm::nmm()
 
 std::string nmm::version()
 {
-	return version_by_name("nmm");
+	return conf::version_by_name("nmm");
 }
 
 bool nmm::prebuilt()

--- a/src/tasks/openssl.cpp
+++ b/src/tasks/openssl.cpp
@@ -11,12 +11,12 @@ openssl::openssl()
 
 const std::string& openssl::version()
 {
-	return versions::by_name("openssl");
+	return version_by_name("openssl");
 }
 
 bool openssl::prebuilt()
 {
-	return prebuilt::by_name("openssl");
+	return prebuilt_by_name("openssl");
 }
 
 fs::path openssl::source_path()
@@ -106,7 +106,7 @@ void openssl::build_and_install_from_source()
 void openssl::configure()
 {
 	run_tool(process_runner(process()
-		.binary(tools::perl::binary())
+		.binary(perl::binary())
 		.arg("Configure")
 		.arg("VC-WIN64A")
 		.arg("--openssldir=", build_path())

--- a/src/tasks/openssl.cpp
+++ b/src/tasks/openssl.cpp
@@ -11,12 +11,12 @@ openssl::openssl()
 
 std::string openssl::version()
 {
-	return version_by_name("openssl");
+	return conf::version_by_name("openssl");
 }
 
 bool openssl::prebuilt()
 {
-	return prebuilt_by_name("openssl");
+	return conf::prebuilt_by_name("openssl");
 }
 
 fs::path openssl::source_path()

--- a/src/tasks/openssl.cpp
+++ b/src/tasks/openssl.cpp
@@ -9,7 +9,7 @@ openssl::openssl()
 {
 }
 
-const std::string& openssl::version()
+std::string openssl::version()
 {
 	return version_by_name("openssl");
 }
@@ -206,8 +206,10 @@ std::smatch openssl::parse_version()
 	std::regex re(R"((\d+)(?:\.(\d+)(?:\.(\d+)([a-zA-Z]+)?)?)?)");
 	std::smatch m;
 
-	if (!std::regex_match(version(), m, re))
-		bail_out("bad openssl version '{}'", version());
+	const auto s = version();
+
+	if (!std::regex_match(s, m, re))
+		bail_out("bad openssl version '{}'", s);
 
 	return m;
 }

--- a/src/tasks/pyqt.cpp
+++ b/src/tasks/pyqt.cpp
@@ -11,17 +11,17 @@ pyqt::pyqt()
 
 std::string pyqt::version()
 {
-	return version_by_name("pyqt");
+	return conf::version_by_name("pyqt");
 }
 
 std::string pyqt::builder_version()
 {
-	return version_by_name("pyqt_builder");
+	return conf::version_by_name("pyqt_builder");
 }
 
 bool pyqt::prebuilt()
 {
-	return prebuilt_by_name("pyqt");
+	return conf::prebuilt_by_name("pyqt");
 }
 
 fs::path pyqt::source_path()

--- a/src/tasks/pyqt.cpp
+++ b/src/tasks/pyqt.cpp
@@ -11,17 +11,17 @@ pyqt::pyqt()
 
 const std::string& pyqt::version()
 {
-	return versions::by_name("pyqt");
+	return version_by_name("pyqt");
 }
 
 const std::string& pyqt::builder_version()
 {
-	return versions::by_name("pyqt_builder");
+	return version_by_name("pyqt_builder");
 }
 
 bool pyqt::prebuilt()
 {
-	return prebuilt::by_name("pyqt");
+	return prebuilt_by_name("pyqt");
 }
 
 fs::path pyqt::source_path()
@@ -106,7 +106,7 @@ void pyqt::sip_build()
 {
 	auto pyqt_env = env::vs_x64()
 		.append_path({
-			tools::qt::bin_path(),
+			qt::bin_path(),
 			python::build_path(),
 			python::source_path(),
 			python::scripts_path()})
@@ -202,12 +202,12 @@ void pyqt::copy_files()
 	// these are needed by PyQt5 while building several projects
 
 	op::copy_file_to_dir_if_better(cx(),
-		tools::qt::bin_path() / "Qt5Core.dll",
+		qt::bin_path() / "Qt5Core.dll",
 		python::build_path(),
 		op::unsafe);   // source file is outside prefix
 
 	op::copy_file_to_dir_if_better(cx(),
-		tools::qt::bin_path() / "Qt5Xml.dll",
+		qt::bin_path() / "Qt5Xml.dll",
 		python::build_path(),
 		op::unsafe);   // source file is outside prefix
 }

--- a/src/tasks/pyqt.cpp
+++ b/src/tasks/pyqt.cpp
@@ -9,12 +9,12 @@ pyqt::pyqt()
 {
 }
 
-const std::string& pyqt::version()
+std::string pyqt::version()
 {
 	return version_by_name("pyqt");
 }
 
-const std::string& pyqt::builder_version()
+std::string pyqt::builder_version()
 {
 	return version_by_name("pyqt_builder");
 }

--- a/src/tasks/python.cpp
+++ b/src/tasks/python.cpp
@@ -11,12 +11,12 @@ python::python()
 
 const std::string& python::version()
 {
-	return versions::by_name("python");
+	return version_by_name("python");
 }
 
 bool python::prebuilt()
 {
-	return prebuilt::by_name("python");
+	return prebuilt_by_name("python");
 }
 
 python::version_info python::parsed_version()
@@ -109,12 +109,13 @@ void python::build_and_install_prebuilt()
 
 void python::fetch_from_source()
 {
-	run_tool(git_clone()
+	run_tool(git(git::clone_or_pull)
 		.url(make_github_url("python", "cpython"))
 		.branch(version())
 		.output(source_path()));
 
-	run_tool(devenv_upgrade(solution_file()));
+	run_tool(vs(vs::upgrade)
+		.solution(solution_file()));
 }
 
 void python::build_and_install_from_source()

--- a/src/tasks/python.cpp
+++ b/src/tasks/python.cpp
@@ -9,7 +9,7 @@ python::python()
 {
 }
 
-const std::string& python::version()
+std::string python::version()
 {
 	return version_by_name("python");
 }
@@ -26,8 +26,10 @@ python::version_info python::parsed_version()
 	std::regex re(R"(v?(\d+)\.(\d+)(?:\.(\d+))?)");
 	std::smatch m;
 
-	if (!std::regex_match(version(), m, re))
-		bail_out("bad python version '{}'", version());
+	const auto s = version();
+
+	if (!std::regex_match(s, m, re))
+		bail_out("bad python version '{}'", s);
 
 	version_info v;
 

--- a/src/tasks/python.cpp
+++ b/src/tasks/python.cpp
@@ -11,12 +11,12 @@ python::python()
 
 std::string python::version()
 {
-	return version_by_name("python");
+	return conf::version_by_name("python");
 }
 
 bool python::prebuilt()
 {
-	return prebuilt_by_name("python");
+	return conf::prebuilt_by_name("python");
 }
 
 python::version_info python::parsed_version()

--- a/src/tasks/python.cpp
+++ b/src/tasks/python.cpp
@@ -111,7 +111,7 @@ void python::build_and_install_prebuilt()
 
 void python::fetch_from_source()
 {
-	run_tool(git(git::clone_or_pull)
+	run_tool(git(task_conf().git_op())
 		.url(make_github_url("python", "cpython"))
 		.branch(version())
 		.output(source_path()));

--- a/src/tasks/sevenz.cpp
+++ b/src/tasks/sevenz.cpp
@@ -11,7 +11,7 @@ sevenz::sevenz()
 
 const std::string& sevenz::version()
 {
-	return versions::by_name("sevenz");
+	return version_by_name("sevenz");
 }
 
 bool sevenz::prebuilt()

--- a/src/tasks/sevenz.cpp
+++ b/src/tasks/sevenz.cpp
@@ -11,7 +11,7 @@ sevenz::sevenz()
 
 std::string sevenz::version()
 {
-	return version_by_name("sevenz");
+	return conf::version_by_name("sevenz");
 }
 
 bool sevenz::prebuilt()

--- a/src/tasks/sevenz.cpp
+++ b/src/tasks/sevenz.cpp
@@ -9,7 +9,7 @@ sevenz::sevenz()
 {
 }
 
-const std::string& sevenz::version()
+std::string sevenz::version()
 {
 	return version_by_name("sevenz");
 }

--- a/src/tasks/sip.cpp
+++ b/src/tasks/sip.cpp
@@ -11,12 +11,12 @@ sip::sip()
 
 const std::string& sip::version()
 {
-	return versions::by_name("sip");
+	return version_by_name("sip");
 }
 
 const std::string& sip::version_for_pyqt()
 {
-	return versions::by_name("pyqt_sip");
+	return version_by_name("pyqt_sip");
 }
 
 bool sip::prebuilt()

--- a/src/tasks/sip.cpp
+++ b/src/tasks/sip.cpp
@@ -9,12 +9,12 @@ sip::sip()
 {
 }
 
-const std::string& sip::version()
+std::string sip::version()
 {
 	return version_by_name("sip");
 }
 
-const std::string& sip::version_for_pyqt()
+std::string sip::version_for_pyqt()
 {
 	return version_by_name("pyqt_sip");
 }
@@ -46,8 +46,10 @@ fs::path sip::module_source_path()
 	std::regex re(R"((\d+)\.(\d+)(?:\.(\d+))?)");
 	std::smatch m;
 
-	if (!std::regex_match(version_for_pyqt(), m, re))
-		bail_out("bad pyqt sip version {}", version_for_pyqt());
+	const auto s = version_for_pyqt();
+
+	if (!std::regex_match(s, m, re))
+		bail_out("bad pyqt sip version {}", s);
 
 	// 12.7
 	const auto dir = m[1].str() + "." + m[2].str();

--- a/src/tasks/sip.cpp
+++ b/src/tasks/sip.cpp
@@ -11,12 +11,12 @@ sip::sip()
 
 std::string sip::version()
 {
-	return version_by_name("sip");
+	return conf::version_by_name("sip");
 }
 
 std::string sip::version_for_pyqt()
 {
-	return version_by_name("pyqt_sip");
+	return conf::version_by_name("pyqt_sip");
 }
 
 bool sip::prebuilt()

--- a/src/tasks/spdlog.cpp
+++ b/src/tasks/spdlog.cpp
@@ -11,7 +11,7 @@ spdlog::spdlog()
 
 std::string spdlog::version()
 {
-	return version_by_name("spdlog");
+	return conf::version_by_name("spdlog");
 }
 
 bool spdlog::prebuilt()

--- a/src/tasks/spdlog.cpp
+++ b/src/tasks/spdlog.cpp
@@ -11,7 +11,7 @@ spdlog::spdlog()
 
 const std::string& spdlog::version()
 {
-	return versions::by_name("spdlog");
+	return version_by_name("spdlog");
 }
 
 bool spdlog::prebuilt()
@@ -26,7 +26,7 @@ fs::path spdlog::source_path()
 
 void spdlog::do_fetch()
 {
-	run_tool(git_clone()
+	run_tool(git(git::clone_or_pull)
 		.url(make_github_url("gabime", "spdlog"))
 		.branch(version())
 		.output(source_path()));

--- a/src/tasks/spdlog.cpp
+++ b/src/tasks/spdlog.cpp
@@ -26,7 +26,7 @@ fs::path spdlog::source_path()
 
 void spdlog::do_fetch()
 {
-	run_tool(git(git::clone_or_pull)
+	run_tool(git(task_conf().git_op())
 		.url(make_github_url("gabime", "spdlog"))
 		.branch(version())
 		.output(source_path()));

--- a/src/tasks/spdlog.cpp
+++ b/src/tasks/spdlog.cpp
@@ -9,7 +9,7 @@ spdlog::spdlog()
 {
 }
 
-const std::string& spdlog::version()
+std::string spdlog::version()
 {
 	return version_by_name("spdlog");
 }

--- a/src/tasks/stylesheets.cpp
+++ b/src/tasks/stylesheets.cpp
@@ -15,6 +15,27 @@ const std::string& stylesheets::version()
 	return s;
 }
 
+std::string stylesheets::paper_lad_6788_version()
+{
+	return version_by_name("ss_paper_lad_6788");
+}
+
+std::string stylesheets::paper_automata_6788_version()
+{
+	return version_by_name("ss_paper_automata_6788");
+}
+
+std::string stylesheets::paper_mono_6788_version()
+{
+	return version_by_name("ss_paper_mono_6788");
+}
+
+std::string stylesheets::dark_mode_1809_6788_version()
+{
+	return version_by_name("ss_dark_mode_1809_6788");
+}
+
+
 bool stylesheets::prebuilt()
 {
 	return false;
@@ -65,29 +86,29 @@ std::vector<stylesheets::release> stylesheets::releases()
 		{
 			"6788-00",
 			"paper-light-and-dark",
-			versions::ss_6788_paper_lad(),
-			versions::ss_6788_paper_lad(),
+			stylesheets::paper_lad_6788_version(),
+			stylesheets::paper_lad_6788_version(),
 		},
 
 		{
 			"6788-00",
 			"paper-automata",
-			versions::ss_6788_paper_automata(),
+			paper_automata_6788_version(),
 			"Paper-Automata"
 		},
 
 		{
 			"6788-00",
 			"paper-mono",
-			versions::ss_6788_paper_mono(),
+			paper_mono_6788_version(),
 			"Paper-Mono"
 		},
 
 		{
 			"6788-00",
 			"1809-dark-mode",
-			versions::ss_6788_1809_dark_mode(),
-			versions::ss_6788_1809_dark_mode()
+			dark_mode_1809_6788_version(),
+			dark_mode_1809_6788_version()
 		}
 	};
 }

--- a/src/tasks/stylesheets.cpp
+++ b/src/tasks/stylesheets.cpp
@@ -16,22 +16,22 @@ std::string stylesheets::version()
 
 std::string stylesheets::paper_lad_6788_version()
 {
-	return version_by_name("ss_paper_lad_6788");
+	return conf::version_by_name("ss_paper_lad_6788");
 }
 
 std::string stylesheets::paper_automata_6788_version()
 {
-	return version_by_name("ss_paper_automata_6788");
+	return conf::version_by_name("ss_paper_automata_6788");
 }
 
 std::string stylesheets::paper_mono_6788_version()
 {
-	return version_by_name("ss_paper_mono_6788");
+	return conf::version_by_name("ss_paper_mono_6788");
 }
 
 std::string stylesheets::dark_mode_1809_6788_version()
 {
-	return version_by_name("ss_dark_mode_1809_6788");
+	return conf::version_by_name("ss_dark_mode_1809_6788");
 }
 
 

--- a/src/tasks/stylesheets.cpp
+++ b/src/tasks/stylesheets.cpp
@@ -9,10 +9,9 @@ stylesheets::stylesheets()
 {
 }
 
-const std::string& stylesheets::version()
+std::string stylesheets::version()
 {
-	static std::string s;
-	return s;
+	return {};
 }
 
 std::string stylesheets::paper_lad_6788_version()

--- a/src/tasks/task.cpp
+++ b/src/tasks/task.cpp
@@ -288,6 +288,11 @@ void task::parallel(std::vector<std::pair<std::string, std::function<void ()>>> 
 		t.join();
 }
 
+task_conf_holder task::task_conf() const
+{
+	return task_conf_holder(names_);
+}
+
 void task::run()
 {
 	threaded_run(name(), [&]

--- a/src/tasks/task.h
+++ b/src/tasks/task.h
@@ -2,11 +2,13 @@
 
 #include "../utility.h"
 #include "../context.h"
+#include "../tools/tools.h"
 
 namespace mob
 {
 
 class task;
+class tool;
 
 void add_task(std::unique_ptr<task> t);
 
@@ -25,7 +27,41 @@ void run_all_tasks();
 void list_tasks(bool err=false);
 
 
-class tool;
+class task_conf_holder
+{
+public:
+	task_conf_holder(std::vector<std::string> names)
+		: names_(std::move(names))
+	{
+	}
+
+	std::string mo_org()
+	{
+		return conf::option_by_name(names_, "mo_org");
+	}
+
+	std::string mo_branch()
+	{
+		return conf::option_by_name(names_, "mo_branch");
+	}
+
+	bool no_pull()
+	{
+		return conf::bool_option_by_name(names_, "no_pull");
+	}
+
+	git::ops git_op()
+	{
+		if (no_pull())
+			return git::clone;
+		else
+			return git::clone_or_pull2;
+	}
+
+private:
+	std::vector<std::string> names_;
+};
+
 
 class task
 {
@@ -79,6 +115,8 @@ protected:
 
 	void threaded_run(std::string name, std::function<void ()> f);
 	void parallel(std::vector<std::pair<std::string, std::function<void ()>>> v);
+
+	task_conf_holder task_conf() const;
 
 private:
 	struct thread_context;

--- a/src/tasks/task.h
+++ b/src/tasks/task.h
@@ -40,7 +40,7 @@ public:
 	const std::vector<std::string>& names() const;
 
 	virtual fs::path get_source_path() const = 0;
-	virtual const std::string& get_version() const = 0;
+	virtual std::string get_version() const = 0;
 	virtual const bool get_prebuilt() const = 0;
 
 	virtual bool is_super() const;
@@ -111,7 +111,7 @@ public:
 		return Task::source_path();
 	}
 
-	const std::string& get_version() const override
+	std::string get_version() const override
 	{
 		return Task::version();
 	}
@@ -142,10 +142,9 @@ public:
 		return {};
 	}
 
-	const std::string& get_version() const override
+	std::string get_version() const override
 	{
-		static std::string s;
-		return s;
+		return {};
 	}
 
 	const bool get_prebuilt() const override

--- a/src/tasks/tasks.h
+++ b/src/tasks/tasks.h
@@ -5,7 +5,6 @@
 #include "../conf.h"
 #include "../utility.h"
 #include "../op.h"
-#include "../tools/tools.h"
 
 namespace mob
 {

--- a/src/tasks/tasks.h
+++ b/src/tasks/tasks.h
@@ -15,8 +15,8 @@ class boost : public basic_task<boost>
 public:
 	boost();
 
-	static const std::string& version();
-	static const std::string& version_vs();
+	static std::string version();
+	static std::string version_vs();
 	static bool prebuilt();
 
 	static fs::path source_path();
@@ -66,7 +66,7 @@ class boost_di : public basic_task<boost_di>
 public:
 	boost_di();
 
-	static const std::string& version();
+	static std::string version();
 	static bool prebuilt();
 
 	static fs::path source_path();
@@ -81,7 +81,7 @@ class bzip2 : public basic_task<bzip2>
 public:
 	bzip2();
 
-	static const std::string& version();
+	static std::string version();
 	static bool prebuilt();
 
 	static fs::path source_path();
@@ -99,7 +99,7 @@ class explorerpp : public basic_task<explorerpp>
 public:
 	explorerpp();
 
-	static const std::string& version();
+	static std::string version();
 	static bool prebuilt();
 
 	static fs::path source_path();
@@ -117,7 +117,7 @@ class fmt : public basic_task<fmt>
 public:
 	fmt();
 
-	static const std::string& version();
+	static std::string version();
 	static bool prebuilt();
 
 	static fs::path source_path();
@@ -137,7 +137,7 @@ class gtest : public basic_task<gtest>
 public:
 	gtest();
 
-	static const std::string& version();
+	static std::string version();
 	static bool prebuilt();
 
 	static fs::path source_path();
@@ -154,7 +154,7 @@ class licenses : public basic_task<licenses>
 public:
 	licenses();
 
-	static const std::string& version();
+	static std::string version();
 	static bool prebuilt();
 
 	static fs::path source_path();
@@ -169,7 +169,7 @@ class libbsarch : public basic_task<libbsarch>
 public:
 	libbsarch();
 
-	static const std::string& version();
+	static std::string version();
 	static bool prebuilt();
 
 	static fs::path source_path();
@@ -189,7 +189,7 @@ class libffi : public basic_task<libffi>
 public:
 	libffi();
 
-	static const std::string& version();
+	static std::string version();
 	static bool prebuilt();
 
 	static fs::path source_path();
@@ -206,8 +206,8 @@ class libloot : public basic_task<libloot>
 public:
 	libloot();
 
-	static const std::string& version();
-	static const std::string& hash();
+	static std::string version();
+	static std::string hash();
 	static bool prebuilt();
 
 	static fs::path source_path();
@@ -227,7 +227,7 @@ class lz4 : public basic_task<lz4>
 public:
 	lz4();
 
-	static const std::string& version();
+	static std::string version();
 	static bool prebuilt();
 
 	static fs::path source_path();
@@ -257,7 +257,7 @@ class modorganizer : public basic_task<modorganizer>
 public:
 	modorganizer(std::string name);
 
-	static const std::string& version();
+	static std::string version();
 	static bool prebuilt();
 
 	static fs::path source_path();
@@ -283,7 +283,7 @@ class ncc : public basic_task<ncc>
 public:
 	ncc();
 
-	static const std::string& version();
+	static std::string version();
 	static bool prebuilt();
 
 	static fs::path source_path();
@@ -300,7 +300,7 @@ class nmm : public basic_task<nmm>
 public:
 	nmm();
 
-	static const std::string& version();
+	static std::string version();
 	static bool prebuilt();
 
 	static fs::path source_path();
@@ -317,7 +317,7 @@ class openssl : public basic_task<openssl>
 public:
 	openssl();
 
-	static const std::string& version();
+	static std::string version();
 	static bool prebuilt();
 
 	static fs::path source_path();
@@ -356,8 +356,8 @@ class pyqt : public basic_task<pyqt>
 public:
 	pyqt();
 
-	static const std::string& version();
-	static const std::string& builder_version();
+	static std::string version();
+	static std::string builder_version();
 	static bool prebuilt();
 
 	static fs::path source_path();
@@ -397,7 +397,7 @@ public:
 
 	python();
 
-	static const std::string& version();
+	static std::string version();
 	static bool prebuilt();
 
 	static version_info parsed_version();
@@ -435,8 +435,8 @@ class sip : public basic_task<sip>
 public:
 	sip();
 
-	static const std::string& version();
-	static const std::string& version_for_pyqt();
+	static std::string version();
+	static std::string version_for_pyqt();
 	static bool prebuilt();
 
 	static fs::path source_path();
@@ -462,7 +462,7 @@ class sevenz : public basic_task<sevenz>
 public:
 	sevenz();
 
-	static const std::string& version();
+	static std::string version();
 	static bool prebuilt();
 
 	static fs::path source_path();
@@ -486,7 +486,7 @@ class spdlog : public basic_task<spdlog>
 public:
 	spdlog();
 
-	static const std::string& version();
+	static std::string version();
 	static bool prebuilt();
 
 	static fs::path source_path();
@@ -510,7 +510,7 @@ public:
 	static std::string dark_mode_1809_6788_version();
 
 	// dummy, doesn't applly
-	static const std::string& version();
+	static std::string version();
 
 protected:
 	void do_fetch() override;
@@ -534,7 +534,7 @@ class usvfs : public basic_task<usvfs>
 public:
 	usvfs();
 
-	static const std::string& version();
+	static std::string version();
 	static bool prebuilt();
 
 	static fs::path source_path();
@@ -562,7 +562,7 @@ class zlib : public basic_task<zlib>
 public:
 	zlib();
 
-	static const std::string& version();
+	static std::string version();
 	static bool prebuilt();
 
 	static fs::path source_path();

--- a/src/tasks/tasks.h
+++ b/src/tasks/tasks.h
@@ -501,10 +501,16 @@ class stylesheets : public basic_task<stylesheets>
 public:
 	stylesheets();
 
-	static const std::string& version();
 	static bool prebuilt();
-
 	static fs::path source_path();
+
+	static std::string paper_lad_6788_version();
+	static std::string paper_automata_6788_version();
+	static std::string paper_mono_6788_version();
+	static std::string dark_mode_1809_6788_version();
+
+	// dummy, doesn't applly
+	static const std::string& version();
 
 protected:
 	void do_fetch() override;

--- a/src/tasks/usvfs.cpp
+++ b/src/tasks/usvfs.cpp
@@ -11,12 +11,12 @@ usvfs::usvfs()
 
 const std::string& usvfs::version()
 {
-	return versions::by_name("usvfs");
+	return version_by_name("usvfs");
 }
 
 bool usvfs::prebuilt()
 {
-	return prebuilt::by_name("usvfs");
+	return prebuilt_by_name("usvfs");
 }
 
 fs::path usvfs::source_path()
@@ -65,7 +65,7 @@ void usvfs::build_and_install_prebuilt()
 
 void usvfs::fetch_from_source()
 {
-	run_tool(git_clone()
+	run_tool(git(git::clone_or_pull)
 		.url(make_github_url(conf::mo_org(), "usvfs"))
 		.branch(version())
 		.output(source_path()));

--- a/src/tasks/usvfs.cpp
+++ b/src/tasks/usvfs.cpp
@@ -11,12 +11,12 @@ usvfs::usvfs()
 
 std::string usvfs::version()
 {
-	return version_by_name("usvfs");
+	return conf::version_by_name("usvfs");
 }
 
 bool usvfs::prebuilt()
 {
-	return prebuilt_by_name("usvfs");
+	return conf::prebuilt_by_name("usvfs");
 }
 
 fs::path usvfs::source_path()
@@ -66,7 +66,7 @@ void usvfs::build_and_install_prebuilt()
 void usvfs::fetch_from_source()
 {
 	run_tool(git(git::clone_or_pull)
-		.url(make_github_url(conf::mo_org(), "usvfs"))
+		.url(make_github_url(conf::mo_org(names()), "usvfs"))
 		.branch(version())
 		.output(source_path()));
 }

--- a/src/tasks/usvfs.cpp
+++ b/src/tasks/usvfs.cpp
@@ -9,7 +9,7 @@ usvfs::usvfs()
 {
 }
 
-const std::string& usvfs::version()
+std::string usvfs::version()
 {
 	return version_by_name("usvfs");
 }

--- a/src/tasks/usvfs.cpp
+++ b/src/tasks/usvfs.cpp
@@ -65,8 +65,8 @@ void usvfs::build_and_install_prebuilt()
 
 void usvfs::fetch_from_source()
 {
-	run_tool(git(git::clone_or_pull)
-		.url(make_github_url(conf::mo_org(names()), "usvfs"))
+	run_tool(git(task_conf().git_op())
+		.url(make_github_url(task_conf().mo_org(), "usvfs"))
 		.branch(version())
 		.output(source_path()));
 }

--- a/src/tasks/zlib.cpp
+++ b/src/tasks/zlib.cpp
@@ -9,7 +9,7 @@ zlib::zlib()
 {
 }
 
-const std::string& zlib::version()
+std::string zlib::version()
 {
 	return version_by_name("zlib");
 }

--- a/src/tasks/zlib.cpp
+++ b/src/tasks/zlib.cpp
@@ -11,7 +11,7 @@ zlib::zlib()
 
 std::string zlib::version()
 {
-	return version_by_name("zlib");
+	return conf::version_by_name("zlib");
 }
 
 bool zlib::prebuilt()

--- a/src/tasks/zlib.cpp
+++ b/src/tasks/zlib.cpp
@@ -11,7 +11,7 @@ zlib::zlib()
 
 const std::string& zlib::version()
 {
-	return versions::by_name("zlib");
+	return version_by_name("zlib");
 }
 
 bool zlib::prebuilt()

--- a/src/tools/cmake.cpp
+++ b/src/tools/cmake.cpp
@@ -13,7 +13,7 @@ cmake::cmake()
 
 fs::path cmake::binary()
 {
-	return tool_by_name("cmake");
+	return conf::tool_by_name("cmake");
 }
 
 void cmake::clean(const context& cx, const fs::path& root)

--- a/src/tools/cmake.cpp
+++ b/src/tools/cmake.cpp
@@ -8,7 +8,26 @@ cmake::cmake()
 	: basic_process_runner("cmake"), gen_(jom), arch_(arch::def)
 {
 	process_
-		.binary(tools::cmake::binary());
+		.binary(binary());
+}
+
+fs::path cmake::binary()
+{
+	return tool_by_name("cmake");
+}
+
+void cmake::clean(const context& cx, const fs::path& root)
+{
+	cx.trace(context::rebuild, "deleting all generator directories");
+
+	for (auto&& [k, g] : all_generators())
+	{
+		op::delete_directory(cx,
+			root / g.output_dir(arch::x86), op::optional);
+
+		op::delete_directory(cx,
+			root / g.output_dir(arch::x64), op::optional);
+	}
 }
 
 cmake& cmake::generator(generators g)
@@ -58,20 +77,6 @@ fs::path cmake::result() const
 	return output_;
 }
 
-void cmake::clean(const context& cx, const fs::path& root)
-{
-	cx.trace(context::rebuild, "deleting all generator directories");
-
-	for (auto&& [k, g] : all_generators())
-	{
-		op::delete_directory(cx,
-			root / g.output_dir(arch::x86), op::optional);
-
-		op::delete_directory(cx,
-			root / g.output_dir(arch::x64), op::optional);
-	}
-}
-
 void cmake::do_run()
 {
 	if (root_.empty())
@@ -110,7 +115,7 @@ const std::map<cmake::generators, cmake::gen_info>& cmake::all_generators()
 
 		{ generators::vs, {
 			"vsbuild",
-			"Visual Studio " + tools::vs::version() + " " + tools::vs::year(),
+			"Visual Studio " + vs::version() + " " + vs::year(),
 			"Win32",
 			"x64"
 	}}

--- a/src/tools/extractor.cpp
+++ b/src/tools/extractor.cpp
@@ -9,6 +9,11 @@ extractor::extractor()
 {
 }
 
+fs::path extractor::binary()
+{
+	return tool_by_name("sevenz");
+}
+
 extractor& extractor::file(const fs::path& file)
 {
 	file_ = file;
@@ -72,12 +77,12 @@ void extractor::do_run()
 		cx_->trace(context::generic, "this is a tar.gz, piping");
 
 		auto extract_tar = process()
-			.binary(tools::sevenz::binary())
+			.binary(binary())
 			.arg("x")
 			.arg("-so", file_);
 
 		auto extract_gz = process()
-			.binary(tools::sevenz::binary())
+			.binary(binary())
 			.arg("x")
 			.arg("-aoa")
 			.arg("-si")
@@ -89,7 +94,7 @@ void extractor::do_run()
 	else
 	{
 		process_ = process()
-			.binary(tools::sevenz::binary())
+			.binary(binary())
 			.arg("x")
 			.arg("-aoa")
 			.arg("-bd")

--- a/src/tools/extractor.cpp
+++ b/src/tools/extractor.cpp
@@ -11,7 +11,7 @@ extractor::extractor()
 
 fs::path extractor::binary()
 {
-	return tool_by_name("sevenz");
+	return conf::tool_by_name("sevenz");
 }
 
 extractor& extractor::file(const fs::path& file)

--- a/src/tools/git.cpp
+++ b/src/tools/git.cpp
@@ -12,7 +12,7 @@ git::git(ops o)
 
 fs::path git::binary()
 {
-	return tool_by_name("git");
+	return conf::tool_by_name("git");
 }
 
 git& git::url(const mob::url& u)
@@ -38,10 +38,15 @@ void git::do_run()
 	switch (op_)
 	{
 		case clone_or_pull:
+		{
 			do_clone_or_pull();
+			break;
+		}
 
 		default:
+		{
 			cx_->bail_out(context::generic, "git unknown op {}", op_);
+		}
 	}
 }
 

--- a/src/tools/jom.cpp
+++ b/src/tools/jom.cpp
@@ -12,7 +12,7 @@ jom::jom()
 
 fs::path jom::binary()
 {
-	return tool_by_name("jom");
+	return conf::tool_by_name("jom");
 }
 
 jom& jom::path(const fs::path& p)

--- a/src/tools/jom.cpp
+++ b/src/tools/jom.cpp
@@ -10,6 +10,11 @@ jom::jom()
 {
 }
 
+fs::path jom::binary()
+{
+	return tool_by_name("jom");
+}
+
 jom& jom::path(const fs::path& p)
 {
 	process_.cwd(p);
@@ -55,7 +60,7 @@ void jom::do_run()
 	}
 
 	process_
-		.binary(tools::jom::binary())
+		.binary(binary())
 		.stderr_filter([](process::filter& f)
 		{
 			if (f.line.find("empower your cores") != std::string::npos)

--- a/src/tools/msbuild.cpp
+++ b/src/tools/msbuild.cpp
@@ -11,6 +11,11 @@ msbuild::msbuild() :
 {
 }
 
+fs::path msbuild::binary()
+{
+	return tool_by_name("msbuild");
+}
+
 msbuild& msbuild::solution(const fs::path& sln)
 {
 	sln_ = sln;
@@ -61,7 +66,7 @@ int msbuild::result() const
 void msbuild::do_run()
 {
 	// 14.2 to v142
-	const auto toolset = "v" + replace_all(tools::vs::toolset(), ".", "");
+	const auto toolset = "v" + replace_all(vs::toolset(), ".", "");
 
 	std::string plat;
 
@@ -95,7 +100,7 @@ void msbuild::do_run()
 	}
 
 	process_
-		.binary(tools::msbuild::binary())
+		.binary(binary())
 		.chcp(65001)
 		.stdout_encoding(encodings::utf8)
 		.stderr_encoding(encodings::utf8)
@@ -112,7 +117,7 @@ void msbuild::do_run()
 	process_
 		.arg("-property:Configuration=", config_, process::quote)
 		.arg("-property:PlatformToolset=" + toolset)
-		.arg("-property:WindowsTargetPlatformVersion=" + tools::vs::sdk())
+		.arg("-property:WindowsTargetPlatformVersion=" + vs::sdk())
 		.arg("-property:Platform=", plat, process::quote)
 		.arg("-verbosity:minimal", process::log_quiet)
 		.arg("-consoleLoggerParameters:ErrorsOnly", process::log_quiet);

--- a/src/tools/msbuild.cpp
+++ b/src/tools/msbuild.cpp
@@ -13,7 +13,7 @@ msbuild::msbuild() :
 
 fs::path msbuild::binary()
 {
-	return tool_by_name("msbuild");
+	return conf::tool_by_name("msbuild");
 }
 
 msbuild& msbuild::solution(const fs::path& sln)

--- a/src/tools/patcher.cpp
+++ b/src/tools/patcher.cpp
@@ -10,6 +10,11 @@ patcher::patcher()
 {
 }
 
+fs::path patcher::binary()
+{
+	return tool_by_name("patch");
+}
+
 patcher& patcher::task(const std::string& name, bool prebuilt)
 {
 	task_ = name;
@@ -98,7 +103,7 @@ void patcher::do_run()
 void patcher::do_patch(const fs::path& patch_file)
 {
 	const auto base = process()
-		.binary(tools::patch::binary())
+		.binary(binary())
 		.arg("--read-only", "ignore")
 		.arg("--strip", "0")
 		.arg("--directory", output_)

--- a/src/tools/patcher.cpp
+++ b/src/tools/patcher.cpp
@@ -12,7 +12,7 @@ patcher::patcher()
 
 fs::path patcher::binary()
 {
-	return tool_by_name("patch");
+	return conf::tool_by_name("patch");
 }
 
 patcher& patcher::task(const std::string& name, bool prebuilt)

--- a/src/tools/tools.cpp
+++ b/src/tools/tools.cpp
@@ -62,32 +62,32 @@ bool tool::interrupted() const
 
 fs::path perl::binary()
 {
-	return tool_by_name("perl");
+	return conf::tool_by_name("perl");
 }
 
 fs::path nasm::binary()
 {
-	return tool_by_name("nasm");
+	return conf::tool_by_name("nasm");
 }
 
 fs::path qt::installation_path()
 {
-	return path_by_name("qt_install");
+	return conf::path_by_name("qt_install");
 }
 
 fs::path qt::bin_path()
 {
-	return path_by_name("qt_bin");
+	return conf::path_by_name("qt_bin");
 }
 
 std::string qt::version()
 {
-	return version_by_name("qt");
+	return conf::version_by_name("qt");
 }
 
 std::string qt::vs_version()
 {
-	return version_by_name("qt_vs");
+	return conf::version_by_name("qt_vs");
 }
 
 
@@ -98,42 +98,42 @@ vs::vs(ops o)
 
 fs::path vs::devenv_binary()
 {
-	return tool_by_name("devenv");
+	return conf::tool_by_name("devenv");
 }
 
 fs::path vs::installation_path()
 {
-	return path_by_name("vs");
+	return conf::path_by_name("vs");
 }
 
 fs::path vs::vswhere()
 {
-	return tool_by_name("vswhere");
+	return conf::tool_by_name("vswhere");
 }
 
 fs::path vs::vcvars()
 {
-	return tool_by_name("vcvars");
+	return conf::tool_by_name("vcvars");
 }
 
 std::string vs::version()
 {
-	return version_by_name("vs");
+	return conf::version_by_name("vs");
 }
 
 std::string vs::year()
 {
-	return version_by_name("vs_year");
+	return conf::version_by_name("vs_year");
 }
 
 std::string vs::toolset()
 {
-	return version_by_name("vs_toolset");
+	return conf::version_by_name("vs_toolset");
 }
 
 std::string vs::sdk()
 {
-	return version_by_name("sdk");
+	return conf::version_by_name("sdk");
 }
 
 vs& vs::solution(const fs::path& sln)
@@ -147,10 +147,15 @@ void vs::do_run()
 	switch (op_)
 	{
 		case upgrade:
+		{
 			do_upgrade();
+			break;
+		}
 
 		default:
+		{
 			cx_->bail_out(context::generic, "vs unknown op {}", op_);
+		}
 	}
 }
 
@@ -184,7 +189,7 @@ nuget::nuget(fs::path sln)
 
 fs::path nuget::binary()
 {
-	return tool_by_name("nuget");
+	return conf::tool_by_name("nuget");
 }
 
 void nuget::do_run()

--- a/src/tools/tools.cpp
+++ b/src/tools/tools.cpp
@@ -72,12 +72,12 @@ fs::path nasm::binary()
 
 fs::path qt::installation_path()
 {
-	return paths::by_name("qt_install");
+	return path_by_name("qt_install");
 }
 
 fs::path qt::bin_path()
 {
-	return paths::by_name("qt_bin");
+	return path_by_name("qt_bin");
 }
 
 std::string qt::version()
@@ -103,7 +103,7 @@ fs::path vs::devenv_binary()
 
 fs::path vs::installation_path()
 {
-	return paths::by_name("vs");
+	return path_by_name("vs");
 }
 
 fs::path vs::vswhere()

--- a/src/tools/tools.cpp
+++ b/src/tools/tools.cpp
@@ -60,12 +60,101 @@ bool tool::interrupted() const
 }
 
 
-devenv_upgrade::devenv_upgrade(fs::path sln)
-	: basic_process_runner("upgrade project"), sln_(std::move(sln))
+fs::path perl::binary()
+{
+	return tool_by_name("perl");
+}
+
+fs::path nasm::binary()
+{
+	return tool_by_name("nasm");
+}
+
+fs::path qt::installation_path()
+{
+	return paths::by_name("qt_install");
+}
+
+fs::path qt::bin_path()
+{
+	return paths::by_name("qt_bin");
+}
+
+std::string qt::version()
+{
+	return version_by_name("qt");
+}
+
+std::string qt::vs_version()
+{
+	return version_by_name("qt_vs");
+}
+
+
+vs::vs(ops o)
+	: basic_process_runner("vs"), op_(o)
 {
 }
 
-void devenv_upgrade::do_run()
+fs::path vs::devenv_binary()
+{
+	return tool_by_name("devenv");
+}
+
+fs::path vs::installation_path()
+{
+	return paths::by_name("vs");
+}
+
+fs::path vs::vswhere()
+{
+	return tool_by_name("vswhere");
+}
+
+fs::path vs::vcvars()
+{
+	return tool_by_name("vcvars");
+}
+
+std::string vs::version()
+{
+	return version_by_name("vs");
+}
+
+std::string vs::year()
+{
+	return version_by_name("vs_year");
+}
+
+std::string vs::toolset()
+{
+	return version_by_name("vs_toolset");
+}
+
+std::string vs::sdk()
+{
+	return version_by_name("sdk");
+}
+
+vs& vs::solution(const fs::path& sln)
+{
+	sln_ = sln;
+	return *this;
+}
+
+void vs::do_run()
+{
+	switch (op_)
+	{
+		case upgrade:
+			do_upgrade();
+
+		default:
+			cx_->bail_out(context::generic, "vs unknown op {}", op_);
+	}
+}
+
+void vs::do_upgrade()
 {
 	if (fs::exists(sln_.parent_path() / "UpgradeLog.htm"))
 	{
@@ -74,7 +163,7 @@ void devenv_upgrade::do_run()
 	}
 
 	process_
-		.binary(tools::devenv::binary())
+		.binary(devenv_binary())
 		.env(env::vs(arch::x64))
 		.arg("/upgrade")
 		.arg(sln_);
@@ -87,10 +176,15 @@ nuget::nuget(fs::path sln)
 	: basic_process_runner("nuget"), sln_(std::move(sln))
 {
 	process_
-		.binary(tools::nuget::binary())
+		.binary(binary())
 		.arg("restore")
 		.arg(sln_)
 		.cwd(sln_.parent_path());
+}
+
+fs::path nuget::binary()
+{
+	return tool_by_name("nuget");
 }
 
 void nuget::do_run()

--- a/src/tools/tools.h
+++ b/src/tools/tools.h
@@ -134,7 +134,9 @@ class git : public basic_process_runner
 public:
 	enum ops
 	{
-		clone_or_pull = 1
+		clone = 1,
+		pull,
+		clone_or_pull2
 	};
 
 
@@ -156,8 +158,8 @@ private:
 	fs::path where_;
 
 	void do_clone_or_pull();
-	void clone();
-	void pull();
+	bool do_clone();
+	void do_pull();
 };
 
 

--- a/src/tools/tools.h
+++ b/src/tools/tools.h
@@ -134,7 +134,7 @@ class git : public basic_process_runner
 public:
 	enum ops
 	{
-		clone_or_pull
+		clone_or_pull = 1
 	};
 
 

--- a/src/tools/tools.h
+++ b/src/tools/tools.h
@@ -41,6 +41,24 @@ private:
 };
 
 
+struct perl
+{
+	static fs::path binary();
+};
+
+struct nasm
+{
+	static fs::path binary();
+};
+
+struct qt
+{
+	static fs::path installation_path();
+	static fs::path bin_path();
+	static std::string version();
+	static std::string vs_version();
+};
+
 
 class downloader : public tool
 {
@@ -111,23 +129,33 @@ private:
 };
 
 
-class git_clone : public basic_process_runner
+class git : public basic_process_runner
 {
 public:
-	git_clone();
+	enum ops
+	{
+		clone_or_pull
+	};
 
-	git_clone& url(const mob::url& u);
-	git_clone& branch(const std::string& name);
-	git_clone& output(const fs::path& dir);
+
+	git(ops o);
+
+	static fs::path binary();
+
+	git& url(const mob::url& u);
+	git& branch(const std::string& name);
+	git& output(const fs::path& dir);
 
 protected:
 	void do_run() override;
 
 private:
+	ops op_;
 	mob::url url_;
 	std::string branch_;
 	fs::path where_;
 
+	void do_clone_or_pull();
 	void clone();
 	void pull();
 };
@@ -137,6 +165,9 @@ class extractor : public basic_process_runner
 {
 public:
 	extractor();
+
+	static fs::path binary();
+
 	extractor& file(const fs::path& file);
 	extractor& output(const fs::path& dir);
 
@@ -155,6 +186,8 @@ class patcher : public basic_process_runner
 {
 public:
 	patcher();
+
+	static fs::path binary();
 
 	patcher& task(const std::string& name, bool prebuilt=false);
 	patcher& file(const fs::path& p);
@@ -184,6 +217,7 @@ public:
 
 	cmake();
 
+	static fs::path binary();
 	static void clean(const context& cx, const fs::path& root);
 
 	cmake& generator(generators g);
@@ -234,6 +268,8 @@ public:
 
 	jom();
 
+	static fs::path binary();
+
 	jom& path(const fs::path& p);
 	jom& target(const std::string& s);
 	jom& def(const std::string& s);
@@ -264,6 +300,8 @@ public:
 
 	msbuild();
 
+	static fs::path binary();
+
 	msbuild& solution(const fs::path& sln);
 	msbuild& projects(const std::vector<std::string>& names);
 	msbuild& parameters(const std::vector<std::string>& params);
@@ -288,16 +326,35 @@ private:
 };
 
 
-class devenv_upgrade : public basic_process_runner
+class vs : public basic_process_runner
 {
 public:
-	devenv_upgrade(fs::path sln);
+	enum ops
+	{
+		upgrade = 1
+	};
+
+	vs(ops o);
+
+	static fs::path devenv_binary();
+	static fs::path installation_path();
+	static fs::path vswhere();
+	static fs::path vcvars();
+	static std::string version();
+	static std::string year();
+	static std::string toolset();
+	static std::string sdk();
+
+	vs& solution(const fs::path& sln);
 
 protected:
 	void do_run() override;
 
 private:
+	ops op_;
 	fs::path sln_;
+
+	void do_upgrade();
 };
 
 
@@ -305,6 +362,8 @@ class nuget : public basic_process_runner
 {
 public:
 	nuget(fs::path sln);
+
+	static fs::path binary();
 
 protected:
 	void do_run() override;

--- a/src/utility.h
+++ b/src/utility.h
@@ -64,7 +64,7 @@ class url;
 class bailed
 {
 public:
-	bailed(std::string s)
+	bailed(std::string s={})
 		: s_(std::move(s))
 	{
 	}


### PR DESCRIPTION
- Merged all the `tools::X` into the actual tools to avoid duplication
- Don't hardcode options, assume a master INI that has all the options
- Everything in one `map`
- Supports multiple INIs and auto detection of INIs alongside the master
- Options per task
- Added `--no-pull`