### PR TITLE
Allow usage of glob-like string for task names.

### DIFF
--- a/src/tasks/task.cpp
+++ b/src/tasks/task.cpp
@@ -35,22 +35,30 @@ void list_tasks(bool err)
 	}
 }
 
-task* find_task(const std::string& name)
+std::vector<task*> find_tasks(const std::string& pattern)
 {
+	std::vector<task*> tasks;
 	for (auto&& t : g_all_tasks)
 	{
 		for (auto&& n : t->names())
 		{
-			if (n == name)
-				return t;
+			if (mob::glob_match(pattern, n)) {
+				tasks.push_back(t);
+				break;
+			}
 		}
 	}
 
-	u8cout << "task " << name << " not found\n";
-	u8cout << "valid tasks:\n";
-	list_tasks(true);
+	if (tasks.empty()) {
 
-	throw bailed("");
+		u8cout << "no task matching " << pattern << " found\n";
+		u8cout << "valid tasks:\n";
+		list_tasks(true);
+
+		throw bailed("");
+	}
+
+	return tasks;
 }
 
 void run_tasks(const std::vector<task*> tasks)
@@ -110,7 +118,7 @@ void gather_super_tasks(std::vector<task*>& tasks, std::set<task*>& seen)
 
 void run_task(const std::string& name)
 {
-	run_tasks({find_task(name)});
+	run_tasks({name});
 }
 
 void run_tasks(const std::vector<std::string>& names)
@@ -133,12 +141,12 @@ void run_tasks(const std::vector<std::string>& names)
 		}
 		else
 		{
-			auto* t = find_task(name);
-
-			if (!seen.contains(t))
-			{
-				tasks.push_back(t);
-				seen.insert(t);
+			for (auto* t : find_tasks(name)) {
+				if (!seen.contains(t))
+				{
+					tasks.push_back(t);
+					seen.insert(t);
+				}
 			}
 		}
 	}

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -318,6 +318,11 @@ url make_appveyor_artifact_url(
 		project + "/artifacts/" + filename + "?job=Platform:%20" + arch_s;
 }
 
+bool glob_match(const std::string& pattern, const std::string& s)
+{
+	return std::regex_match(s, std::regex{ replace_all(pattern, "*", ".*") });
+}
+
 std::string replace_all(
 	std::string s, const std::string& from, const std::string& to)
 {

--- a/src/utility.h
+++ b/src/utility.h
@@ -294,6 +294,8 @@ url make_prebuilt_url(const std::string& filename);
 url make_appveyor_artifact_url(
 	arch a, const std::string& project, const std::string& filename);
 
+bool glob_match(const std::string& pattern, const std::string& s);
+
 std::string replace_all(
 	std::string s, const std::string& from, const std::string& to);
 


### PR DESCRIPTION
Allow kind-of-basic glob-matching for task names:

```
> mob build uibase game_fallout[34] installer_*
0.03     [uibase]                              fetching
0.04     [game_fallout4]                       fetching
0.04     [installer_bain]                      fetching
0.04     [installer_manua]                     fetching
0.04     [game_fallout3]                       fetching
0.04     [installer_quick]                     fetching
0.04     [installer_fomod]                     fetching
0.04     [installer_ncc]                       fetching
0.04     [installer_bundl]                     fetching
1.48     [uibase]                              build and install
4.58     [game_fallout3]                       build and install
5.96     [game_fallout4]                       build and install
7.34     [installer_bain]                      build and install
8.73     [installer_manua]                     build and install
10.10    [installer_bundl]                     build and install
11.47    [installer_quick]                     build and install
12.82    [installer_fomod]                     build and install
14.21    [installer_ncc]                       build and install
15.64                                          mob done
```

I find this pretty useful when you work on all installer or game plugins for instance, and it should not break anything. I went with a very straightforward implementation using `std::regex` since this is not a critical part of the code.