### PR TITLE
WIP reminder of some fixes

### DIFF
--- a/src/conf.cpp
+++ b/src/conf.cpp
@@ -990,7 +990,7 @@ void init_options(
 			{
 				if (po.task == "_override")
 				{
-					conf::set_for_task("override", po.section, po.key, po.value);
+					conf::set_for_task("_override", po.section, po.key, po.value);
 				}
 				else
 				{

--- a/src/tools/git.cpp
+++ b/src/tools/git.cpp
@@ -379,7 +379,7 @@ void git::do_revert_ts()
 	{
 		process_ = make_process()
 			.stderr_level(context::level::trace)
-			.arg("checkout")
+			.arg("checkout").flags(process::allow_failure)
 			.arg(p)
 			.cwd(root_);
 


### PR DESCRIPTION
This temporarily fixed some issues with revert_ts() as it tried to revert some ts files that are not actually source controlled.
The other change fixed a typo I think that made --revert-ts not work.
This is just here as a quick reference about the the issues and what was done as a temp fix for when you have time later.
