### PR TITLE
Added -products argument to vswhere

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -1,4 +1,4 @@
-$installationPath = .\third-party\bin\vswhere.exe -nologo -prerelease -latest -property installationPath
+$installationPath = .\third-party\bin\vswhere.exe -products * -nologo -prerelease -latest -property installationPath
 if (! $?) {
     Write-Error "vswhere returned $LastExitCode"
     exit $LastExitCode

--- a/src/conf.cpp
+++ b/src/conf.cpp
@@ -592,6 +592,7 @@ fs::path find_vs()
 
 	auto p = process()
 		.binary(vs::vswhere())
+		.arg("-products", "*")
 		.arg("-prerelease")
 		.arg("-version", vs::version())
 		.arg("-property", "installationPath")


### PR DESCRIPTION
This enabled me to work with VS Build Tools, but I think it ought to be checked against non Build Tools Visual Studio instances as a sanity check before being merged. I also noticed, `src/conf.cpp` lacks an argument of `-latest`. I'm not sure if that's by design or what, but I think it should at least be noted.