### PR TITLE
Clarify global versus command option usage

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -167,11 +167,9 @@ If `mob` is unable to find the Qt installation directory, it can be specified in
 ## Command line
 Do `mob --help` for global options and the list of available commands. Do `mob <command> --help` for more help about a command.
 
+To use global options with command options, ensure command options are together, with no global options in the middle.
+
 ### Global options
-Global options should be specified before the subcommand, e.g.
-```powershell
-mob --ini another.ini build
-```
 
 | Option              | Description |
 | ---                 | --- |

--- a/readme.md
+++ b/readme.md
@@ -168,6 +168,10 @@ If `mob` is unable to find the Qt installation directory, it can be specified in
 Do `mob --help` for global options and the list of available commands. Do `mob <command> --help` for more help about a command.
 
 ### Global options
+Global options should be specified before the subcommand, e.g.
+```powershell
+mob --ini another.ini build
+```
 
 | Option              | Description |
 | ---                 | --- |

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -39,6 +39,8 @@ void help(const clipp::group& g, const std::string& more)
 		<< clipp::documentation(g, options_df)
 		<< "\n";
 
+	u8cout << "\nTo use global options with command options, ensure command options are together, with no global options in the middle.\n";
+
 	if (!more.empty())
 		u8cout << "\n" << more << "\n";
 }


### PR DESCRIPTION
When clipp sees an option that doesn't belong to the current group, it leaves that group, never to return again. That means there can't be global options between command-specific options or the later command-specific ones will be interpreted as global ones and break.

This has tripped me up on two unrelated occasions, and I've needed to bother isa to discover the cause, so I'm adding it to the readme and usage message. I've done my best to make it both accurate and not sound like an error message when it's not an error (e.g. when explicitly using `--help` or doing something else that stopped arguments from parsing correctly).

I attempted to integrate it with clipp's built-in line wrapping, but that wasn't especially accessible and didn't want to work with the u8stream, so in the end, I just made it print normally.